### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/foamgaby/97885a67-eef4-49aa-a12e-d76a06491134/566afe1a-52b8-41c8-ac91-80e4cd564a98/_apis/work/boardbadge/92bdd072-a636-45ef-94e9-a3d5caf66a7d)](https://dev.azure.com/foamgaby/97885a67-eef4-49aa-a12e-d76a06491134/_boards/board/t/566afe1a-52b8-41c8-ac91-80e4cd564a98/Microsoft.RequirementCategory)
 # Kubernetes Examples
 
 This directory contains a number of examples of how to run real applications


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/foamgaby/97885a67-eef4-49aa-a12e-d76a06491134/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.